### PR TITLE
added version 1.0.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "type": "magento2-module",
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "Daniel van der Linden",


### PR DESCRIPTION
Since we use declarative schema now, we do not have a version in `module.xml` anymore. Hence, I added the version in `composer.json` and bumped it to `1.0.0`. Could you merge and create a new release @Spaggel?